### PR TITLE
When two players have the same score, show Draw result

### DIFF
--- a/app/components/Results.js
+++ b/app/components/Results.js
@@ -102,16 +102,19 @@ class Results extends React.Component {
         </div>
       )
     }
+
+    var isDraw = this.state.winner.score === this.state.loser.score
+
     return(
       <div className='row'>
         <Player
-          label='Winner'
+          label={ isDraw ? 'Draw': 'Winner' }
           score={winner.score}
           profile={winner.profile}
         />
 
         <Player
-          label='Loser'
+          label={ isDraw ? 'Draw': 'Loser' }
           score={loser.score}
           profile={loser.profile}
         />

--- a/app/components/Results.js
+++ b/app/components/Results.js
@@ -4,7 +4,7 @@ var queryString = require('query-string');
 var api = require('../utils/api');
 var Link = require('react-router-dom').Link;
 var PlayerPreview = require('./PlayerPreview');
-var Loading = require('./Loading')
+var Loading = require('./Loading');
 
 
 function Profile(props) {
@@ -26,7 +26,7 @@ function Profile(props) {
 }
 
 Profile.propTypes = {
-  info: PropTypes.object.isRequired,
+  info: PropTypes.object.isRequired
 }
 
 function Player(props) {
@@ -52,8 +52,7 @@ class Results extends React.Component {
     super(props);
 
     this.state = {
-      winner: null,
-      loser: null,
+      results: null,
       error: null,
       loading: true
     }
@@ -69,7 +68,7 @@ class Results extends React.Component {
         return this.setState(function () {
           return {
             error: 'Looks like there was error. Check that both users exist on Github',
-            laoding: false,
+            loading: false
           }
         });
       }
@@ -77,21 +76,30 @@ class Results extends React.Component {
       this.setState(function () {
         return {
           error: null,
-          winner: results[0],
-          loser: results[1],
+          results: results,
           loading: false
         }
       });
     }.bind(this));
   }
+
+  getResultText(currentPlayer, otherPlayer) {
+    return currentPlayer.score > otherPlayer.score ?
+      'Winner' : currentPlayer.score === otherPlayer.score ?
+        'Draw' : 'Loser'
+  }
+
   render() {
     var error = this.state.error;
-    var winner = this.state.winner;
-    var loser = this.state.loser;
+    var results = this.state.results;
     var loading = this.state.loading;
 
     if (loading === true) {
       return <Loading />
+    }
+
+    if (!error && (results === null || results.length !== 2)) {
+      error = 'Unexpected API response. Please try again.';
     }
 
     if (error) {
@@ -103,20 +111,18 @@ class Results extends React.Component {
       )
     }
 
-    var isDraw = this.state.winner.score === this.state.loser.score
-
     return(
       <div className='row'>
         <Player
-          label={ isDraw ? 'Draw': 'Winner' }
-          score={winner.score}
-          profile={winner.profile}
+          label={this.getResultText(results[0], results[1])}
+          score={results[0].score}
+          profile={results[0].profile}
         />
 
         <Player
-          label={ isDraw ? 'Draw': 'Loser' }
-          score={loser.score}
-          profile={loser.profile}
+          label={this.getResultText(results[1], results[0])}
+          score={results[1].score}
+          profile={results[1].profile}
         />
       </div>
     )

--- a/app/utils/api.js
+++ b/app/utils/api.js
@@ -48,16 +48,9 @@ function getUserData (player) {
   })
 }
 
-function sortPlayers(players) {
-  return players.sort(function(a,b){
-    return b.score - a.score;
-  })
-}
-
 module.exports = {
   battle: function (players) {
       return axios.all(players.map(getUserData))
-        .then(sortPlayers)
         .catch(handleError)
   },
   fetchPopularRepos: function (language) {


### PR DESCRIPTION
In my opinion, a better solution would be to modify the `api` results. Returning the "players" in order from highest to lowest score, means you can't map the score back to the original player order. It's an odd user experience to plugin a player 1 and a player 2, and then always have the highest score on the left side (essentially swapping player 1 and player 2 when player 2 is the winner). If the players were calculated and returned back in the original order they were submitted, then the scores could easily be mapped back to the original UI, resulting in a better UX (in my opinion of course). 

![draw-state](https://user-images.githubusercontent.com/1076168/31599521-aa6d8a9c-b207-11e7-9e52-0167a41c6edd.PNG)

Closes #3 

**UPDATE**
I ended up doing exactly as I suggested above and reworking the API to not over process the results. If for some reason you disagree, I can drop the last commit and only have the Draw state update.

![player-positions-dont-change](https://user-images.githubusercontent.com/1076168/31599531-b46f70b4-b207-11e7-8a8a-2755e258055c.PNG)
